### PR TITLE
✨🐛 Add DevCyclePR workflow config

### DIFF
--- a/.github/workflows/DevCyclePR.yml
+++ b/.github/workflows/DevCyclePR.yml
@@ -1,0 +1,19 @@
+name: PR Insights
+
+on:
+  workflow_call:
+
+jobs:
+  dvc-feature-flag-insights:
+    runs-on: ubuntu-latest
+    name: Generate DevCycle PR Insights
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - uses: DevCycleHQ/feature-flag-pr-insights-action@v2.0.0
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          project-key: ${{ secrets.DVC_PROJECT_KEY }}
+          client-id: ${{ secrets.DVC_CLIENT_ID }}
+          client-secret: ${{ secrets.DVC_CLIENT_SECRET }}


### PR DESCRIPTION
This commit adds the DevCyclePR workflow configuration file to the `.github/workflows` directory. The workflow is triggered by a `workflow_call` event and consists of a single job named `dvc-feature-flag-insights`. This job runs on `ubuntu-latest` and is responsible for generating DevCycle PR insights. The job includes steps to checkout the code and utilize the
`DevCycleHQ/feature-flag-pr-insights-action@v2.0.0` action. The action requires several secrets to be provided in order to function properly.